### PR TITLE
feat: Add option for extra repos

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -7,6 +7,14 @@ on:
     branches: [main]
   # Allow for workflow inheritance
   workflow_call:
+    inputs:
+      extra-repositories:
+        description: |
+          One or more extra CRAN-like repositories to include in the `repos` global option.
+          This is a space-separated list of repositories.
+        required: false
+        type: string
+        default: ""
 
 name: R-CMD-check
 
@@ -22,6 +30,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          extra-repositories: "${{ inputs.extra-repositories }}"
 
       - uses: r-lib/actions/setup-pandoc@v2
 


### PR DESCRIPTION
Adds an option for consumer workflows to specify extra repositories.

Pre-requisite for https://github.com/phuse-org/devops/issues/14